### PR TITLE
Use build-schema and wasm-test inside std, instead of user defined

### DIFF
--- a/concordium-std-derive/Cargo.toml
+++ b/concordium-std-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-std-derive"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Concordium <info@concordium.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -17,3 +17,7 @@ proc-macro2 = "1.0"
 
 [lib]
 proc-macro = true
+
+[features]
+wasm-test = []
+build-schema = []

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-std"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Concordium <info@concordium.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -15,8 +15,7 @@ readme = "../README.md"
 wee_alloc="0.4.5"
 
 [dependencies.concordium-std-derive]
-# path = "../concordium-std-derive"
-version = "=0.1"
+version = "=0.2"
 
 [dependencies.concordium-contracts-common]
 # path = "../../concordium-contracts-common"
@@ -27,6 +26,8 @@ default-features = false
 default = ["std"]
 
 std = ["concordium-contracts-common/std"]
+wasm-test = ["concordium-std-derive/wasm-test"]
+build-schema = ["concordium-std-derive/build-schema"]
 
 [lib]
 crate-type = ["rlib"]

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -68,7 +68,7 @@ extern "C" {
     /// Slot time (in milliseconds) from chain meta data
     pub(crate) fn get_slot_time() -> u64;
 
-    #[cfg(all(debug_assertions, target_arch = "wasm32"))]
+    #[cfg(all(feature = "wasm-test", target_arch = "wasm32"))]
     /// Reporting back an error, only exists in debug mode
     pub(crate) fn report_error(
         msg_start: *const u8,

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -442,7 +442,7 @@ impl HasActions for ActionsTree {
 /// Reports back an error to the host when compiled to wasm
 /// Used internally, not meant to be called directly by contract writers
 #[doc(hidden)]
-#[cfg(all(debug_assertions, target_arch = "wasm32"))]
+#[cfg(all(feature = "wasm-test", target_arch = "wasm32"))]
 pub fn report_error(message: &str, filename: &str, line: u32, column: u32) {
     let msg_bytes = message.as_bytes();
     let filename_bytes = filename.as_bytes();
@@ -461,5 +461,5 @@ pub fn report_error(message: &str, filename: &str, line: u32, column: u32) {
 /// Reports back an error to the host when compiled to wasm
 /// Used internally, not meant to be called directly by contract writers
 #[doc(hidden)]
-#[cfg(not(all(debug_assertions, target_arch = "wasm32")))]
+#[cfg(not(all(feature = "wasm-test", target_arch = "wasm32")))]
 pub fn report_error(_message: &str, _filename: &str, _line: u32, _column: u32) {}


### PR DESCRIPTION

Before we required the smart contract developer to specify the `build-schema` and `wasm-test` feature when building schema and running test compiled to Wasm.
This PR moves the feature flags to be part of `concordium-std` and `concordium-std-derive`, changing how they are built instead of having the user include hard-defined features.