### PR TITLE
Expose policy to smart contracts.

### DIFF
--- a/concordium-std-derive/Cargo.toml
+++ b/concordium-std-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-std-derive"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Concordium <info@concordium.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -68,7 +68,7 @@ pub fn init(attr: TokenStream, item: TokenStream) -> TokenStream {
             #[export_name = #wasm_export_fn_name]
             pub extern "C" fn #rust_export_fn_name(amount: Amount) -> i32 {
                 use concordium_std::{Logger, trap};
-                let ctx = InitContextExtern::open(());
+                let ctx = ExternContext::<InitContextExtern>::open(());
                 let mut state = ContractState::open(());
                 let mut logger = Logger::init();
                 match #fn_name(&ctx, amount, &mut logger, &mut state) {
@@ -82,7 +82,7 @@ pub fn init(attr: TokenStream, item: TokenStream) -> TokenStream {
             #[export_name = #wasm_export_fn_name]
             pub extern "C" fn #rust_export_fn_name(amount: Amount) -> i32 {
                 use concordium_std::{Logger, trap};
-                let ctx = InitContextExtern::open(());
+                let ctx = ExternContext::<InitContextExtern>::open(());
                 let mut logger = Logger::init();
                 match #fn_name(&ctx, amount, &mut logger) {
                     Ok(state) => {
@@ -143,7 +143,7 @@ pub fn receive(attr: TokenStream, item: TokenStream) -> TokenStream {
         #[export_name = #wasm_export_fn_name]
         pub extern "C" fn #rust_export_fn_name(amount: Amount) -> i32 {
             use concordium_std::{SeekFrom, ContractState, Logger};
-            let ctx = ReceiveContextExtern::open(());
+            let ctx = ExternContext::<ReceiveContextExtern>::open(());
             let mut state = ContractState::open(());
             let mut logger = Logger::init();
             let res: Result<Action, _> = #fn_name(&ctx, amount, &mut logger, &mut state);
@@ -160,7 +160,7 @@ pub fn receive(attr: TokenStream, item: TokenStream) -> TokenStream {
             #[export_name = #wasm_export_fn_name]
             pub extern "C" fn #rust_export_fn_name(amount: Amount) -> i32 {
                 use concordium_std::{SeekFrom, ContractState, Logger, trap};
-                let ctx = ReceiveContextExtern::open(());
+                let ctx = ExternContext::<ReceiveContextExtern>::open(());
                 let mut logger = Logger::init();
                 let mut state_bytes = ContractState::open(());
                 if let Ok(mut state) = (&mut state_bytes).get() {
@@ -765,9 +765,7 @@ pub fn contract_state(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 #[cfg(not(feature = "build-schema"))]
 #[proc_macro_attribute]
-pub fn contract_state(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    item
-}
+pub fn contract_state(_attr: TokenStream, item: TokenStream) -> TokenStream { item }
 
 /// Derive the `SchemaType` trait for a type.
 #[cfg(feature = "build-schema")]
@@ -822,9 +820,7 @@ pub fn schema_type_derive(input: TokenStream) -> TokenStream {
     SchemaType,
     attributes(size_length, map_size_length, set_size_length, string_size_length)
 )]
-pub fn schema_type_derive(_input: TokenStream) -> TokenStream {
-    TokenStream::new()
-}
+pub fn schema_type_derive(_input: TokenStream) -> TokenStream { TokenStream::new() }
 
 #[cfg(feature = "build-schema")]
 fn schema_type_field_type(field: &syn::Field) -> proc_macro2::TokenStream {
@@ -912,9 +908,7 @@ pub fn concordium_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Sets the cfg for testing targeting either Wasm and native.
 #[cfg(feature = "wasm-test")]
 #[proc_macro_attribute]
-pub fn concordium_cfg_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
-    item
-}
+pub fn concordium_cfg_test(_attr: TokenStream, item: TokenStream) -> TokenStream { item }
 
 /// Sets the cfg for testing targeting either Wasm and native.
 #[cfg(not(feature = "wasm-test"))]

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -870,7 +870,7 @@ fn schema_type_fields(fields: &syn::Fields) -> proc_macro2::TokenStream {
 }
 
 /// Derive the appropriate export for an annotated test function, when feature
-/// "wasm-test" is enabled, otherwise behaves like #[test].
+/// "wasm-test" is enabled, otherwise behaves like `#[test]`.
 #[cfg(feature = "wasm-test")]
 #[proc_macro_attribute]
 pub fn concordium_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
@@ -895,7 +895,7 @@ pub fn concordium_test(_attr: TokenStream, item: TokenStream) -> TokenStream {
 }
 
 /// Derive the appropriate export for an annotated test function, when feature
-/// "wasm-test" is enabled, otherwise behaves like #[test].
+/// "wasm-test" is enabled, otherwise behaves like `#[test]`.
 #[cfg(not(feature = "wasm-test"))]
 #[proc_macro_attribute]
 pub fn concordium_test(_attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -15,11 +15,12 @@ readme = "../README.md"
 wee_alloc="0.4.5"
 
 [dependencies.concordium-std-derive]
-version = "=0.2"
+# path = "../concordium-std-derive"
+version = "=0.3"
 
 [dependencies.concordium-contracts-common]
 # path = "../../concordium-contracts-common"
-version = "=0.1"
+version = "=0.3"
 default-features = false
 
 [features]

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -17,13 +17,13 @@ wee_alloc="0.4.5"
 [dependencies.concordium-std-derive]
 # path = "../concordium-std-derive"
 git = "https://github.com/Concordium/concordium-std.git"
-branch = "expose-policy"
+branch = "main"
 version = "=0.3"
 
 [dependencies.concordium-contracts-common]
 # path = "../../concordium-contracts-common"
 git = "https://github.com/Concordium/concordium-contracts-common.git"
-branch = "expose-policy"
+branch = "main"
 version = "=0.2"
 default-features = false
 

--- a/concordium-std/Cargo.toml
+++ b/concordium-std/Cargo.toml
@@ -16,11 +16,15 @@ wee_alloc="0.4.5"
 
 [dependencies.concordium-std-derive]
 # path = "../concordium-std-derive"
+git = "https://github.com/Concordium/concordium-std.git"
+branch = "expose-policy"
 version = "=0.3"
 
 [dependencies.concordium-contracts-common]
 # path = "../../concordium-contracts-common"
-version = "=0.3"
+git = "https://github.com/Concordium/concordium-contracts-common.git"
+branch = "expose-policy"
+version = "=0.2"
 default-features = false
 
 [features]

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -236,7 +236,11 @@ impl HasPolicy for Policy<AttributesCursor> {
         let (tag_value_len, num_read) = unsafe {
             let mut tag_value_len = MaybeUninit::<[u8; 2]>::uninit();
             // Should succeed, otherwise host violated precondition.
-            let num_read = get_policy_section(tag_value_len.as_mut_ptr() as *mut u8, 2, self.items.current_position);
+            let num_read = get_policy_section(
+                tag_value_len.as_mut_ptr() as *mut u8,
+                2,
+                self.items.current_position,
+            );
             (tag_value_len.assume_init(), num_read)
         };
         self.items.current_position += num_read;
@@ -303,6 +307,15 @@ impl Iterator for PoliciesIterator {
             },
         })
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let rem = self.remaining_items as usize;
+        (rem, Some(rem))
+    }
+}
+
+impl ExactSizeIterator for PoliciesIterator {
+    fn len(&self) -> usize { self.remaining_items as usize }
 }
 
 impl<T: sealed::ContextType> HasCommonData for ExternContext<T> {

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -295,14 +295,15 @@ impl Iterator for PoliciesIterator {
         let created_at = u64::from_le_bytes(created_at_part);
         let valid_to = u64::from_le_bytes(valid_to_part);
         let remaining_items = u16::from_le_bytes(len_part);
-        self.pos += u32::from(u16::from_le_bytes(skip_part));
+        let attributes_start = self.pos + 2 + 4 + 8 + 8 + 2;
+        self.pos += u32::from(u16::from_le_bytes(skip_part)) + 2;
         self.remaining_items -= 1;
         Some(Policy {
             identity_provider,
             created_at,
             valid_to,
             items: AttributesCursor {
-                current_position: 0,
+                current_position: attributes_start,
                 remaining_items,
             },
         })

--- a/concordium-std/src/impls.rs
+++ b/concordium-std/src/impls.rs
@@ -335,7 +335,7 @@ impl<T: sealed::ContextType> HasCommonData for ExternContext<T> {
 }
 
 /// # Trait implementations for the init context
-impl HasInitContext<()> for ExternContext<crate::types::InitContextExtern> {
+impl HasInitContext for ExternContext<crate::types::InitContextExtern> {
     type InitData = ();
 
     /// Create a new init context by using an external call.
@@ -354,7 +354,7 @@ impl HasInitContext<()> for ExternContext<crate::types::InitContextExtern> {
 }
 
 /// # Trait implementations for the receive context
-impl HasReceiveContext<()> for ExternContext<crate::types::ReceiveContextExtern> {
+impl HasReceiveContext for ExternContext<crate::types::ReceiveContextExtern> {
     type ReceiveData = ();
 
     /// Create a new receive context

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -31,7 +31,8 @@
 //!
 //! # Panic handler
 //! When compiled without the `std` feature this crate sets the panic handler
-//! to a no-op.
+//! so that it terminates the process immediately, without any unwinding or
+//! prints.
 //!
 //! # Build for generating a module schema
 //! **WARNING** Building with this feature enabled is meant for tooling, and the
@@ -124,6 +125,9 @@ pub use alloc::{string, string::String, string::ToString, vec, vec::Vec};
 pub use core::convert;
 /// Re-export.
 #[cfg(not(feature = "std"))]
+pub use core::marker;
+/// Re-export.
+#[cfg(not(feature = "std"))]
 pub use core::mem;
 
 /// Re-export.
@@ -132,6 +136,8 @@ pub use std::collections;
 /// Re-export.
 #[cfg(feature = "std")]
 pub use std::convert;
+#[cfg(feature = "std")]
+pub use std::marker;
 /// Re-export.
 #[cfg(feature = "std")]
 pub use std::mem;

--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -129,6 +129,8 @@ pub use core::marker;
 /// Re-export.
 #[cfg(not(feature = "std"))]
 pub use core::mem;
+#[cfg(feature = "std")]
+pub(crate) use std::vec;
 
 /// Re-export.
 #[cfg(feature = "std")]

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -30,6 +30,12 @@ extern "C" {
     // of bytes written. The location is assumed to contain enough memory to
     // write the requested length into.
     pub(crate) fn get_parameter_section(param_bytes: *mut u8, length: u32, offset: u32) -> u32;
+    // Get the size of the policy.
+    pub(crate) fn get_policy_size() -> u32;
+    // Write a section of the policy to the given location. Return the number
+    // of bytes written. The location is assumed to contain enough memory to
+    // write the requested length into.
+    pub(crate) fn get_policy_section(policy_bytes: *mut u8, length: u32, offset: u32) -> u32;
     // Add a log item.
     pub(crate) fn log_event(start: *const u8, length: u32);
     // returns how many bytes were read.
@@ -119,6 +125,18 @@ mod host_dummy_functions {
     #[no_mangle]
     pub(crate) extern "C" fn get_parameter_section(
         _param_bytes: *mut u8,
+        _length: u32,
+        _offset: u32,
+    ) -> u32 {
+        unimplemented!("Dummy function! Not to be executed")
+    }
+    #[no_mangle]
+    pub(crate) extern "C" fn get_policy_size() -> u32 {
+        unimplemented!("Dummy function! Not to be executed")
+    }
+    #[no_mangle]
+    pub(crate) extern "C" fn get_policy_section(
+        _policy_bytes: *mut u8,
         _length: u32,
         _offset: u32,
     ) -> u32 {

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -30,8 +30,6 @@ extern "C" {
     // of bytes written. The location is assumed to contain enough memory to
     // write the requested length into.
     pub(crate) fn get_parameter_section(param_bytes: *mut u8, length: u32, offset: u32) -> u32;
-    // Get the size of the policy.
-    pub(crate) fn get_policy_size() -> u32;
     // Write a section of the policy to the given location. Return the number
     // of bytes written. The location is assumed to contain enough memory to
     // write the requested length into.

--- a/concordium-std/src/prims.rs
+++ b/concordium-std/src/prims.rs
@@ -129,10 +129,6 @@ mod host_dummy_functions {
         unimplemented!("Dummy function! Not to be executed")
     }
     #[no_mangle]
-    pub(crate) extern "C" fn get_policy_size() -> u32 {
-        unimplemented!("Dummy function! Not to be executed")
-    }
-    #[no_mangle]
     pub(crate) extern "C" fn get_policy_section(
         _policy_bytes: *mut u8,
         _length: u32,

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -11,14 +11,14 @@
 //! ```rust
 //! // Some contract
 //! #[init(contract = "noop")]
-//! fn contract_init<I: HasInitContext<()>, L: HasLogger>(
+//! fn contract_init<I: HasInitContext, L: HasLogger>(
 //!     ctx: &I,
 //!     _amount: Amount,
 //!     _logger: &mut L,
 //! ) -> InitResult<State> { ... }
 //!
 //! #[receive(contract = "noop", name = "receive")]
-//! fn contract_receive<R: HasReceiveContext<()>, L: HasLogger, A: HasActions>(
+//! fn contract_receive<R: HasReceiveContext, L: HasLogger, A: HasActions>(
 //!     ctx: &R,
 //!     amount: Amount,
 //!     logger: &mut L,
@@ -147,7 +147,7 @@ pub struct ContextTest<'a, C> {
 ///
 /// ```rust
 /// #[init(contract = "noop")]
-/// fn contract_init<I: HasInitContext<()>, L: HasLogger>(
+/// fn contract_init<I: HasInitContext, L: HasLogger>(
 ///     ctx: &I,
 ///     _amount: Amount,
 ///     _logger: &mut L,
@@ -209,7 +209,7 @@ pub struct InitOnlyDataTest {
 /// Creating a context for running unit tests
 /// ```rust
 /// #[receive(contract = "mycontract", name = "receive")]
-/// fn contract_receive<R: HasReceiveContext<()>, L: HasLogger, A: HasActions>(
+/// fn contract_receive<R: HasReceiveContext, L: HasLogger, A: HasActions>(
 ///     ctx: &R,
 ///     amount: Amount,
 ///     logger: &mut L,
@@ -397,7 +397,7 @@ impl<'a, C> HasCommonData for ContextTest<'a, C> {
     }
 }
 
-impl<'a> HasInitContext<()> for InitContextTest<'a> {
+impl<'a> HasInitContext for InitContextTest<'a> {
     type InitData = ();
 
     fn open(_data: Self::InitData) -> Self { InitContextTest::default() }
@@ -407,7 +407,7 @@ impl<'a> HasInitContext<()> for InitContextTest<'a> {
     }
 }
 
-impl<'a> HasReceiveContext<()> for ReceiveContextTest<'a> {
+impl<'a> HasReceiveContext for ReceiveContextTest<'a> {
     type ReceiveData = ();
 
     fn open(_data: Self::ReceiveData) -> Self { ReceiveContextTest::default() }

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -359,6 +359,8 @@ impl HasChainMetadata for ChainMetaTest {
 }
 
 impl HasPolicy for TestPolicy {
+    fn identity_provider(&self) -> IdentityProvider { self.policy.identity_provider }
+
     fn created_at(&self) -> TimestampMillis { self.policy.created_at }
 
     fn valid_to(&self) -> TimestampMillis { self.policy.valid_to }

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -76,6 +76,46 @@ pub struct ChainMetaTest {
     pub(crate) slot_time:        Option<SlotTime>,
 }
 
+/// Policy type used by init and receive contexts for testing.
+#[derive(Debug, Clone)]
+pub struct TestPolicy {
+    position:   usize,
+    pub policy: OwnedPolicy,
+}
+
+impl TestPolicy {
+    pub fn new(policy: OwnedPolicy) -> Self {
+        Self {
+            position: 0,
+            policy,
+        }
+    }
+}
+
+/// Placeholder for the common data shared between the `InitContext` and
+/// `ReceiveContext`. This type is a technicality, see `InitContext` and
+/// `ReceiveContext` for the types to use.
+///
+/// # Default
+/// Defaults to having all the fields unset, and constructing
+/// [`ChainMetaTest`](struct.ChainMetaTest.html) using default.
+#[derive(Default, Clone)]
+pub struct CommonDataTest<'a> {
+    pub(crate) metadata: ChainMetaTest,
+    pub(crate) parameter: Option<&'a [u8]>,
+    /// Policy of the creator.
+    pub(crate) policy: Option<TestPolicy>,
+}
+
+/// Context used for testing. The type parameter C is used to determine whether
+/// this will be an init or receive context.
+#[derive(Default, Clone)]
+#[doc(inline)]
+pub struct ContextTest<'a, C> {
+    pub common:        CommonDataTest<'a>,
+    pub(crate) custom: C,
+}
+
 /// Placeholder for the initial context. All the fields can be set optionally
 /// and the getting an unset field will result in calling
 /// [`fail!`](../macro.fail.html). Use only in tests!
@@ -97,7 +137,7 @@ pub struct ChainMetaTest {
 /// Creating an empty context and setting the `slot_time` metadata.
 /// ```
 /// let mut ctx = InitContextTest::empty();
-/// ctx.metadata.set_slot_time(1609459200);
+/// ctx.common.metadata.set_slot_time(1609459200);
 /// ```
 ///
 /// # Use case example
@@ -129,14 +169,11 @@ pub struct ChainMetaTest {
 ///     }
 /// }
 /// ```
-/// # Default
-/// Defaults to having all the fields unset, and constructing
-/// [`ChainMetaTest`](struct.ChainMetaTest.html) using default.
-#[derive(Default, Clone)]
-pub struct InitContextTest<'a> {
-    pub metadata:           ChainMetaTest,
-    pub(crate) parameter:   Option<&'a [u8]>,
-    pub(crate) init_origin: Option<AccountAddress>,
+pub type InitContextTest<'a> = ContextTest<'a, InitOnlyDataTest>;
+
+#[derive(Default)]
+pub struct InitOnlyDataTest {
+    init_origin: Option<AccountAddress>,
 }
 
 /// Placeholder for the receiving context. All the fields can be set optionally
@@ -162,7 +199,7 @@ pub struct InitContextTest<'a> {
 /// Creating an empty context and setting the `slot_time` metadata.
 /// ```
 /// let mut ctx = ReceiveContextTest::empty();
-/// ctx.metadata.set_slot_time(1609459200);
+/// ctx.common.metadata.set_slot_time(1609459200);
 /// ```
 ///
 /// # Use case example
@@ -194,10 +231,10 @@ pub struct InitContextTest<'a> {
 ///     }
 /// }
 /// ```
-#[derive(Default, Clone)]
-pub struct ReceiveContextTest<'a> {
-    pub metadata:            ChainMetaTest,
-    pub(crate) parameter:    Option<&'a [u8]>,
+pub type ReceiveContextTest<'a> = ContextTest<'a, ReceiveOnlyDataTest>;
+
+#[derive(Default)]
+pub struct ReceiveOnlyDataTest {
     pub(crate) invoker:      Option<AccountAddress>,
     pub(crate) self_address: Option<ContractAddress>,
     pub(crate) self_balance: Option<Amount>,
@@ -236,56 +273,58 @@ impl ChainMetaTest {
     }
 }
 
+impl<'a, C> ContextTest<'a, C> {
+    /// Set the `policy` of the creator.
+    pub fn set_policy(&mut self, value: TestPolicy) -> &mut Self {
+        self.common.policy = Some(value);
+        self
+    }
+
+    pub fn set_parameter(&mut self, value: &'a [u8]) -> &mut Self {
+        self.common.parameter = Some(value);
+        self
+    }
+}
+
 impl<'a> InitContextTest<'a> {
     /// Create an `InitContextTest` where every field is unset, and getting any
     /// of the fields will result in [`fail!`](../macro.fail.html).
     pub fn empty() -> Self { Default::default() }
 
-    /// Set the parameter bytes of the `InitContextTest`
-    pub fn set_parameter(&mut self, value: &'a [u8]) -> &mut Self {
-        self.parameter = Some(value);
-        self
-    }
-
     /// Set `init_origin` in the `InitContextTest`
     pub fn set_init_origin(&mut self, value: AccountAddress) -> &mut Self {
-        self.init_origin = Some(value);
+        self.custom.init_origin = Some(value);
         self
     }
 }
 
 impl<'a> ReceiveContextTest<'a> {
-    /// Create an `InitContextTest` where every field is unset, and getting any
-    /// of the fields will result in [`fail!`](../macro.fail.html).
+    /// Create a `ReceiveContextTest` where every field is unset, and getting
+    /// any of the fields will result in [`fail!`](../macro.fail.html).
     pub fn empty() -> Self { Default::default() }
 
-    pub fn set_parameter(&mut self, value: &'a [u8]) -> &mut Self {
-        self.parameter = Some(value);
-        self
-    }
-
     pub fn set_invoker(&mut self, value: AccountAddress) -> &mut Self {
-        self.invoker = Some(value);
+        self.custom.invoker = Some(value);
         self
     }
 
     pub fn set_self_address(&mut self, value: ContractAddress) -> &mut Self {
-        self.self_address = Some(value);
+        self.custom.self_address = Some(value);
         self
     }
 
     pub fn set_self_balance(&mut self, value: Amount) -> &mut Self {
-        self.self_balance = Some(value);
+        self.custom.self_balance = Some(value);
         self
     }
 
     pub fn set_sender(&mut self, value: Address) -> &mut Self {
-        self.sender = Some(value);
+        self.custom.sender = Some(value);
         self
     }
 
     pub fn set_owner(&mut self, value: AccountAddress) -> &mut Self {
-        self.owner = Some(value);
+        self.custom.owner = Some(value);
         self
     }
 }
@@ -319,46 +358,63 @@ impl HasChainMetadata for ChainMetaTest {
     }
 }
 
-impl<'a> HasInitContext<()> for InitContextTest<'a> {
-    type InitData = ();
+impl HasPolicy for TestPolicy {
+    fn created_at(&self) -> TimestampMillis { self.policy.created_at }
+
+    fn valid_to(&self) -> TimestampMillis { self.policy.valid_to }
+
+    fn next_item(&mut self, buf: &mut [u8; 31]) -> Option<(AttributeTag, u8)> {
+        if let Some(item) = self.policy.items.get(self.position) {
+            let len = item.1.len();
+            buf[0..len].copy_from_slice(&item.1);
+            self.position += 1;
+            Some((item.0, len as u8))
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, C> HasCommonData for ContextTest<'a, C> {
     type MetadataType = ChainMetaTest;
     type ParamType = Cursor<&'a [u8]>;
+    type PolicyType = TestPolicy;
+
+    fn parameter_cursor(&self) -> Self::ParamType {
+        Cursor::new(unwrap_ctx_field(self.common.parameter, "parameter"))
+    }
+
+    fn metadata(&self) -> &Self::MetadataType { &self.common.metadata }
+
+    fn policy(&self) -> Self::PolicyType { unwrap_ctx_field(self.common.policy.clone(), "policy") }
+}
+
+impl<'a> HasInitContext<()> for InitContextTest<'a> {
+    type InitData = ();
 
     fn open(_data: Self::InitData) -> Self { InitContextTest::default() }
 
-    fn init_origin(&self) -> AccountAddress { unwrap_ctx_field(self.init_origin, "init_origin") }
-
-    fn parameter_cursor(&self) -> Self::ParamType {
-        Cursor::new(unwrap_ctx_field(self.parameter, "parameter"))
+    fn init_origin(&self) -> AccountAddress {
+        unwrap_ctx_field(self.custom.init_origin, "init_origin")
     }
-
-    fn metadata(&self) -> &Self::MetadataType { &self.metadata }
 }
 
 impl<'a> HasReceiveContext<()> for ReceiveContextTest<'a> {
-    type MetadataType = ChainMetaTest;
-    type ParamType = Cursor<&'a [u8]>;
     type ReceiveData = ();
 
     fn open(_data: Self::ReceiveData) -> Self { ReceiveContextTest::default() }
 
-    fn parameter_cursor(&self) -> Self::ParamType {
-        Cursor::new(unwrap_ctx_field(self.parameter, "parameter"))
-    }
-
-    fn metadata(&self) -> &Self::MetadataType { &self.metadata }
-
-    fn invoker(&self) -> AccountAddress { unwrap_ctx_field(self.invoker, "invoker") }
+    fn invoker(&self) -> AccountAddress { unwrap_ctx_field(self.custom.invoker, "invoker") }
 
     fn self_address(&self) -> ContractAddress {
-        unwrap_ctx_field(self.self_address, "self_address")
+        unwrap_ctx_field(self.custom.self_address, "self_address")
     }
 
-    fn self_balance(&self) -> Amount { unwrap_ctx_field(self.self_balance, "self_balance") }
+    fn self_balance(&self) -> Amount { unwrap_ctx_field(self.custom.self_balance, "self_balance") }
 
-    fn sender(&self) -> Address { unwrap_ctx_field(self.sender, "sender") }
+    fn sender(&self) -> Address { unwrap_ctx_field(self.custom.sender, "sender") }
 
-    fn owner(&self) -> AccountAddress { unwrap_ctx_field(self.owner, "owner") }
+    fn owner(&self) -> AccountAddress { unwrap_ctx_field(self.custom.owner, "owner") }
 }
 
 impl<'a> HasParameter for Cursor<&'a [u8]> {

--- a/concordium-std/src/test_infrastructure.rs
+++ b/concordium-std/src/test_infrastructure.rs
@@ -109,7 +109,7 @@ pub struct CommonDataTest<'a> {
     pub(crate) parameter: Option<&'a [u8]>,
     /// Policy of the creator. We keep the `Option` wrapper
     /// in order that the user can be warned that they are using a policy.
-    /// Thus there is a distinction between `Option<Vec::new()>` and
+    /// Thus there is a distinction between `Some(Vec::new())` and
     /// `Vec::new()`.
     policies: Option<Vec<TestPolicy>>,
 }
@@ -117,7 +117,6 @@ pub struct CommonDataTest<'a> {
 /// Context used for testing. The type parameter C is used to determine whether
 /// this will be an init or receive context.
 #[derive(Default, Clone)]
-#[doc(inline)]
 pub struct ContextTest<'a, C> {
     pub common:        CommonDataTest<'a>,
     pub(crate) custom: C,

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -64,14 +64,15 @@ pub trait HasCommonData {
     type PolicyType: HasPolicy;
     type MetadataType: HasChainMetadata;
     type ParamType: HasParameter + Read;
-    /// Policy of the sender of the message.
+    type PolicyIteratorType: Iterator<Item = Self::PolicyType>;
+    /// Policies of the sender of the message.
     /// For init methods this is the would-be creator of the contract,
-    /// for the receive this is the policy of the immediate sender.
+    /// for the receive this is the policies of the immediate sender.
     ///
-    /// In the latter case, if the sender is an account then it is the policy of
-    /// the account, if it is a contract then it is the policy of the
+    /// In the latter case, if the sender is an account then it is the policies
+    /// of the account, if it is a contract then it is the policies of the
     /// creator of the contract.
-    fn policy(&self) -> Self::PolicyType;
+    fn policies(&self) -> Self::PolicyIteratorType;
     /// Get the reference to chain metadata
     fn metadata(&self) -> &Self::MetadataType;
     /// Get the cursor to the parameter.

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -180,3 +180,26 @@ pub trait HasActions {
     /// If the execution of the first action fails, try the second.
     fn or_else(self, el: Self) -> Self;
 }
+
+/// Add optimized unwrap behaviour that aborts the process instead of
+/// panicking.
+pub trait UnwrapAbort {
+    /// The underlying result type of the unwrap, in case of success.
+    type Unwrap;
+    /// Unwrap or call [trap](./fn.trap.html). In contrast to
+    /// the unwrap methods on [Option::unwrap](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap)
+    /// this method will tend to produce smaller code, at the cost of the
+    /// ability to handle the panic.
+    /// This is intended to be used only in `Wasm` code, where panics cannot be
+    /// handled anyhow.
+    fn unwrap_abort(self) -> Self::Unwrap;
+}
+
+/// Analogue of the `expect` methods on types such as [Option](https://doc.rust-lang.org/std/option/enum.Option.html),
+/// but useful in a Wasm setting.
+pub trait ExpectReport {
+    type Unwrap;
+    /// Like the default `expect` on, e.g., `Result`, but calling
+    /// [fail](macro.fail.html) with the given message, instead of `panic`.
+    fn expect_report(self, msg: &str) -> Self::Unwrap;
+}

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -64,7 +64,7 @@ pub trait HasCommonData {
     type PolicyType: HasPolicy;
     type MetadataType: HasChainMetadata;
     type ParamType: HasParameter + Read;
-    type PolicyIteratorType: Iterator<Item = Self::PolicyType>;
+    type PolicyIteratorType: ExactSizeIterator<Item = Self::PolicyType>;
     /// Policies of the sender of the message.
     /// For init methods this is the would-be creator of the contract,
     /// for the receive this is the policies of the immediate sender.

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -37,6 +37,9 @@ pub trait HasChainMetadata {
 /// low-level style to enable efficient traversal of all the attributes without
 /// any allocations.
 pub trait HasPolicy {
+    /// Identity provider who signed the identity object the credential is
+    /// derived from.
+    fn identity_provider(&self) -> IdentityProvider;
     /// Beginning of the month in milliseconds since unix epoch when the
     /// credential was created.
     fn created_at(&self) -> TimestampMillis;

--- a/concordium-std/src/traits.rs
+++ b/concordium-std/src/traits.rs
@@ -80,7 +80,7 @@ pub trait HasCommonData {
 }
 
 /// Types which can act as init contexts.
-pub trait HasInitContext<Error: Default>: HasCommonData {
+pub trait HasInitContext<Error: Default = ()>: HasCommonData {
     /// Data needed to open the context.
     type InitData;
     /// Open the init context for reading and accessing values.
@@ -90,7 +90,7 @@ pub trait HasInitContext<Error: Default>: HasCommonData {
 }
 
 /// Types which can act as receive contexts.
-pub trait HasReceiveContext<Error: Default>: HasCommonData {
+pub trait HasReceiveContext<Error: Default = ()>: HasCommonData {
     type ReceiveData;
 
     /// Open the receive context for reading and accessing values.
@@ -110,7 +110,7 @@ pub trait HasReceiveContext<Error: Default>: HasCommonData {
 }
 
 /// A type that can serve as the contract state type.
-pub trait HasContractState<Error: Default>
+pub trait HasContractState<Error: Default = ()>
 where
     Self: Read,
     Self: Write<Err = Error>,

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -202,7 +202,7 @@ macro_rules! claim_ne {
 /// }
 ///
 /// #[receive(contract = "mycontract", name = "receive")]
-/// fn contract_receive<R: HasReceiveContext<()>, L: HasLogger, A: HasActions>(
+/// fn contract_receive<R: HasReceiveContext, L: HasLogger, A: HasActions>(
 ///     ctx: &R,
 ///     receive_amount: Amount,
 ///     logger: &mut L,
@@ -228,7 +228,7 @@ pub type ReceiveResult<A> = Result<A, Reject>;
 /// }
 ///
 /// #[init(contract = "mycontract")]
-/// fn contract_init<R: HasReceiveContext<()>, L: HasLogger, A: HasActions>(
+/// fn contract_init<R: HasReceiveContext, L: HasLogger, A: HasActions>(
 ///     ctx: &R,
 ///     receive_amount: Amount,
 ///     logger: &mut L,

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -10,6 +10,17 @@ pub struct Parameter {
     pub(crate) current_position: u32,
 }
 
+/// A type representing the attributes, lazily acquired from the host.
+#[derive(Default)]
+pub struct AttributesCursor {
+    /// Current position of the cursor, starting from 0.
+    /// Note that this is only for the variable attributes.
+    /// `created_at` and `valid_to` will require.
+    pub(crate) current_position: u32,
+    /// The number of remaining items in the policy.
+    pub(crate) remaining_items: u16,
+}
+
 /// A type representing the logger.
 #[derive(Default)]
 pub struct Logger {
@@ -225,8 +236,25 @@ pub type ReceiveResult<A> = Result<A, Reject>;
 /// ```
 pub type InitResult<S> = Result<S, Reject>;
 
-pub struct InitContextExtern {}
-
-pub struct ReceiveContextExtern {}
+/// Context backed by host functions.
+#[derive(Default)]
+pub struct ExternContext<T: sealed::ContextType> {
+    marker: crate::marker::PhantomData<T>,
+}
 
 pub struct ChainMetaExtern {}
+
+#[derive(Default)]
+pub(crate) struct InitContextExtern;
+#[derive(Default)]
+pub(crate) struct ReceiveContextExtern;
+
+pub(crate) mod sealed {
+    use super::*;
+    /// Marker trait intended to indicate which context type we have.
+    /// This is deliberately a sealed trait, so that it is only implementable
+    /// by types in this crate.
+    pub trait ContextType {}
+    impl ContextType for InitContextExtern {}
+    impl ContextType for ReceiveContextExtern {}
+}

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -245,9 +245,9 @@ pub struct ExternContext<T: sealed::ContextType> {
 pub struct ChainMetaExtern {}
 
 #[derive(Default)]
-pub(crate) struct InitContextExtern;
+pub struct InitContextExtern;
 #[derive(Default)]
-pub(crate) struct ReceiveContextExtern;
+pub struct ReceiveContextExtern;
 
 pub(crate) mod sealed {
     use super::*;


### PR DESCRIPTION
Credentials on accounts have policies. This exposes them to smart contracts in a reasonably high-level way.

The serialization of policies is currently undocumented, but it follows the schema of 
- created-at, 8 bytes, little endian
- valid-to, 8 bytes, little endian
- number of attributes, 2 bytes, little endian,
- for each attribute
  - tag, 1 byte
  - length of the attribute, 1 byte (value at most 31)
  - attribute value

In order to minimize the amount of essentially duplicated code this PR also factors out the "common" functionality shared by init and receive methods into a separate trait `HasCommonData`. 