### PR TITLE
Make amount and logger optional

### DIFF
--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -59,8 +59,8 @@ fn contains_attribute<'a, I: IntoIterator<Item = &'a Meta>>(iter: I, name: &str)
 /// # Optional attributes
 ///
 /// ## `payable`: Make function accept an amount of GTU
-/// Without setting the `payable` attribute, the code function will reject any
-/// none-zero amount of GTU, supplied with the transaction. This means we are
+/// Without setting the `payable` attribute, the generated function will reject
+/// any non-zero amount of GTU supplied with the transaction. This means we are
 /// required to explicitly mark our functions as `payable`, if they are to
 /// accept GTU.
 ///
@@ -92,7 +92,7 @@ fn contains_attribute<'a, I: IntoIterator<Item = &'a Meta>>(iter: I, name: &str)
 ///
 /// If `low_level` is set, the signature must contain an extra argument of type
 /// `&mut ContractState` found in `concordium-std`, which gives access to
-/// manipulating the contract state bytes directly. This means there is not need
+/// manipulating the contract state bytes directly. This means there is no need
 /// to return the contract state and the return type becomes `InitResult<()>`.
 ///
 /// ### Example
@@ -105,7 +105,7 @@ fn contains_attribute<'a, I: IntoIterator<Item = &'a Meta>>(iter: I, name: &str)
 /// To make schema generation to include the parameter for this function, add
 /// the attribute `parameter` and set it equal to a string literal containing
 /// the name of the type used for the parameter. The parameter type must
-/// implement the SchemaType trait, which for most cases can be derive
+/// implement the SchemaType trait, which for most cases can be derived
 /// automatically.
 ///
 /// ### Example
@@ -221,8 +221,8 @@ pub fn init(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// # Optional attributes
 ///
 /// ## `payable`: Make function accept an amount of GTU
-/// Without setting the `payable` attribute, the code function will reject any
-/// none-zero amount of GTU, supplied with the transaction. This means we are
+/// Without setting the `payable` attribute, the function will reject any
+/// non-zero amount of GTU, supplied with the transaction. This means we are
 /// required to explicitly mark our functions as `payable`, if they are to
 /// accept GTU.
 ///
@@ -264,10 +264,10 @@ pub fn init(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// ```
 ///
 /// ## `parameter="<Param>"`: Generate schema for parameter
-/// To make schema generation to include the parameter for this function, add
+/// To make schema generation include the parameter for this function, add
 /// the attribute `parameter` and set it equal to a string literal containing
 /// the name of the type used for the parameter. The parameter type must
-/// implement the SchemaType trait, which for most cases can be derive
+/// implement the SchemaType trait, which for most cases can be derived
 /// automatically.
 ///
 /// ### Example


### PR DESCRIPTION
This PR introduces a `payable` and a `enable_logger` attribute for both the `#[init]` and `#[receive]` proc macro.

A payable init/receive function is allowing the amount to *not* be zero.

### Without having `payable` and `enable_logger`

- The init function takes just the init context as argument (also the state if `low_level` is set).<br>
- Receive functions take the receive context and the current state.

```rust
#[init(contract = "two-step-transfer", parameter = "InitParams")]
fn contract_init(ctx: &impl HasInitContext<()>) -> Result<State, InitError> {
```

Code for ensuring the amount is zero is generated.

Notice: the amount and the logger are not arguments anymore in this case.

### Adding `payable`

- init/receive functions take an extra argument, which is the `amount: Amount` and it is positioned right after the context.
- The code ensuring the amount is zero is *not* generated in this case.

```rust
#[init(contract = "two-step-transfer", parameter = "InitParams", payable)]
fn contract_init(ctx: &impl HasInitContext<()>, amount: Amount) -> Result<State, InitError> {
```

### Adding `enable_logger`

- init/receive functions take an extra argument, which is the `logger: impl HasLogger` and it is positioned to the right of the amount if `payable` is also set otherwise to the right of the context.

```rust
#[init(contract = "two-step-transfer", parameter = "InitParams", payable, enable_logger)]
fn contract_init(ctx: &impl HasInitContext<()>, amount: Amount, logger: &impl HasLogger) -> Result<State, InitError> {
```
