### PR TITLE
Fix the fail macro.

### DIFF
--- a/concordium-std/src/lib.rs
+++ b/concordium-std/src/lib.rs
@@ -72,10 +72,10 @@
 //! **Note** This feature is used by `cargo-concordium`, when building for
 //! testing and for most cases this feature should not be set manually.
 
-#![cfg_attr(not(feature = "std"), no_std, feature(alloc_error_handler))]
+#![cfg_attr(not(feature = "std"), no_std, feature(alloc_error_handler, core_intrinsics))]
 
 #[cfg(not(feature = "std"))]
-extern crate alloc;
+pub extern crate alloc;
 
 #[cfg(not(feature = "std"))]
 #[alloc_error_handler]
@@ -97,6 +97,9 @@ pub use std::process::abort as trap;
 #[cfg(all(not(feature = "std"), target_arch = "wasm32"))]
 #[inline(always)]
 pub fn trap() -> ! { unsafe { core::arch::wasm32::unreachable() } }
+#[cfg(all(not(feature = "std"), not(target_arch = "wasm32")))]
+#[inline(always)]
+pub fn trap() -> ! { core::intrinsics::abort() }
 
 #[cfg(not(feature = "std"))]
 #[panic_handler]

--- a/concordium-std/src/types.rs
+++ b/concordium-std/src/types.rs
@@ -112,6 +112,7 @@ macro_rules! ensure_ne {
 /// The `fail` macro is used for testing as a substitute for the panic macro.
 /// It reports back error information to the host.
 /// Used only in testing.
+#[cfg(feature = "std")]
 #[macro_export]
 macro_rules! fail {
     () => {
@@ -122,10 +123,28 @@ macro_rules! fail {
     };
     ($($arg:tt),+) => {
         {
-            #[cfg(feature = "std")]
             let msg = format!($($arg),+);
-            #[cfg(not(feature = "std"))]
-            let msg = &alloc::format!($($arg),+);
+            $crate::test_infrastructure::report_error(&msg, file!(), line!(), column!());
+            panic!(msg)
+        }
+    };
+}
+
+/// The `fail` macro is used for testing as a substitute for the panic macro.
+/// It reports back error information to the host.
+/// Used only in testing.
+#[cfg(not(feature = "std"))]
+#[macro_export]
+macro_rules! fail {
+    () => {
+        {
+            $crate::test_infrastructure::report_error("", file!(), line!(), column!());
+            panic!()
+        }
+    };
+    ($($arg:tt),+) => {
+        {
+            let msg = &$crate::alloc::format!($($arg),+);
             $crate::test_infrastructure::report_error(&msg, file!(), line!(), column!());
             panic!(msg)
         }


### PR DESCRIPTION
As it was before the macro generated the code with a `#[cfg(feature = ...)]
directive, which is both unhygienic, as well as buggy.