### PR TITLE
Improve error reporting when procedural macros are misused.

### DIFF
--- a/concordium-std-derive/Cargo.toml
+++ b/concordium-std-derive/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-syn = { version = "1.0", features = [ "full", "extra-traits" ] }
+syn = { version = "1.0.54", features = [ "full", "extra-traits" ] }
 quote = "=1.0.0"
 proc-macro2 = "1.0"
 

--- a/concordium-std-derive/src/lib.rs
+++ b/concordium-std-derive/src/lib.rs
@@ -1146,6 +1146,7 @@ pub fn schema_type_derive(input: TokenStream) -> TokenStream {
 )]
 pub fn schema_type_derive(_input: TokenStream) -> TokenStream { TokenStream::new() }
 
+#[cfg(feature = "build-schema")]
 fn or_else_joined<A>(
     a: syn::Result<Option<A>>,
     b: impl FnOnce() -> syn::Result<Option<A>>,


### PR DESCRIPTION
An example, forgotten amount in a function argument
```console
error: Incorrect number of function arguments, the expected arguments are (ctx: &impl HasReceiveContext, amount: Amount, state: &mut MyState) 
   --> src/lib.rs:140:5
    |
140 | /     _ctx: &impl HasReceiveContext,
141 | |     _state: &mut State,
    | |_______________________^

error: aborting due to previous error
```

This could be further refined to localize the error more precisely, but that can come in the future.